### PR TITLE
Prevent XXE vulnerability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
         }
     },
     "require": {
-        "php": ">=7.1",
-        "lib-libxml": "*"
+        "php": ">=7.3",
+        "lib-libxml": ">=2.9.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9",


### PR DESCRIPTION
# Changed log

- To prevent the XXE vulnerability, it should let the `libxml` be `2.9.0` version at least.
- Since this package requires `php-7.1` version at least, it should add `php-7.1` and `php-7.2` versions on Travis CI.the
    - It seems that the `PHPUnit:^9` requires `php-7.3` version at least and `Phan:^4` requires `php-7.2` at least, and it should let this package require `php-7.3` version at least.

Some useful references are as follows:

- https://www.php.net/manual/en/function.libxml-disable-entity-loader.php
- https://php.watch/versions/8.0/libxml_disable_entity_loader-deprecation